### PR TITLE
Log failed responses

### DIFF
--- a/samples/With/Worker.cs
+++ b/samples/With/Worker.cs
@@ -24,6 +24,10 @@ public class Worker : BackgroundService
             {
                 _logger.LogInformation("Timeout!");
             }
+            catch(Exception e)
+            {
+                _logger.LogError(e.Message);
+            }
 
             await Task.Delay(10000, stoppingToken);
         }

--- a/samples/Without/Worker.cs
+++ b/samples/Without/Worker.cs
@@ -20,9 +20,13 @@ public class Worker : BackgroundService
             {
                 await _client.GetAsync("https://httpstat.us/404?sleep=3000", stoppingToken);
             }
-            catch (TaskCanceledException e)
+            catch (TaskCanceledException)
             {
                 _logger.LogInformation("Timeout!");
+            }
+            catch(Exception e)
+            {
+                _logger.LogError(e.Message);
             }
 
             await Task.Delay(10000, stoppingToken);

--- a/source/MinimalHttpLogger/MinimalHttpLogger.cs
+++ b/source/MinimalHttpLogger/MinimalHttpLogger.cs
@@ -58,7 +58,7 @@ internal class RequestEndOnlyLogger : DelegatingHandler
         {
             throw new ArgumentNullException(nameof(request));
         }
-        var requestUri = request.RequestUri.ToString(); //SendAsync modifies req uri in case of redirects (?!), so making a local copy
+        var requestUri = request.RequestUri?.ToString(); //SendAsync modifies req uri in case of redirects (?!), so making a local copy
         var stopwatch = ValueStopwatch.StartNew();
         try
         {

--- a/source/MinimalHttpLogger/MinimalHttpLogger.cs
+++ b/source/MinimalHttpLogger/MinimalHttpLogger.cs
@@ -60,10 +60,17 @@ internal class RequestEndOnlyLogger : DelegatingHandler
         }
         var requestUri = request.RequestUri.ToString(); //SendAsync modifies req uri in case of redirects (?!), so making a local copy
         var stopwatch = ValueStopwatch.StartNew();
-        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        _logger.LogInformation("{Method} {Uri} - {StatusCode} {StatusCodeLiteral} in {Time}ms", request.Method, requestUri, $"{(int)response.StatusCode}", $"{response.StatusCode}", stopwatch.GetElapsedTime().TotalMilliseconds);
-
-        return response;
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("{Method} {Uri} - {StatusCode} {StatusCodeLiteral} in {Time}ms", request.Method, requestUri, $"{(int)response.StatusCode}", $"{response.StatusCode}", stopwatch.GetElapsedTime().TotalMilliseconds);
+            return response;
+        }
+        catch(Exception)
+        {
+            _logger.LogInformation("{Method} {Uri} failed to respond in {Time}ms", request.Method, requestUri, stopwatch.GetElapsedTime().TotalMilliseconds);
+            throw;
+        }
     }
 
     internal struct ValueStopwatch


### PR DESCRIPTION
In the event of HttpRequestExceptions (no response), logs the request url & re-throws.

Microsoft logs 2 (out of 4) statements followed by an `HttpRequestException`:

```
info: LogicalHandler[100] Start processing HTTP request GET https://httpstat.us/200?sleep=13000
info: ClientHandler[100] Sending HTTP request GET https://httpstat.us/200?sleep=13000
```

Minimal logger:
```
info: GET https://httpstat.us/200?sleep=13000 failed to respond in 883.8377ms
```